### PR TITLE
fix: update file naming convention in accessing files guide

### DIFF
--- a/src/content/docs/guides/accessing-files.mdx
+++ b/src/content/docs/guides/accessing-files.mdx
@@ -53,15 +53,11 @@ The path to your Stardate files in Terminal is:
 
 ## File Naming Convention
 
-Stardate saves your files with names that include timestamps to help you identify when they were created. The naming format is:
-
-```
-YYYY-MM-DD_HH-MM-SS
-```
+Stardate saves your files with descriptive names that include timestamps to help you identify when they were created. The naming format is:
 
 For example:
-- `2023-05-15_09-32-45.wav` (audio recording)
-- `2023-05-15_09-32-45.txt` (transcription)
+- `Stardate Recording 2024-01-30 at 20.00.49.wav` (audio recording)
+- `Stardate Log 2024-01-30 at 20.00.49.txt` (transcription)
 
 ## Working with Your Files
 


### PR DESCRIPTION
Updates the file naming convention examples in the accessing files guide to show the correct format as reported in the feedback.

Fixes #5

Generated with [Claude Code](https://claude.ai/code)